### PR TITLE
Another fix for the Binding.eval! - encode/decode base64 since apparentl...

### DIFF
--- a/lib/serializable_proc/binding.rb
+++ b/lib/serializable_proc/binding.rb
@@ -29,7 +29,7 @@ class SerializableProc
     private
 
       def declare_vars
-        @declare_vars ||= @vars.map{|(k,v)| "#{k} = Marshal.load(%q|#{mdump(v)}|)" } * '; '
+        @declare_vars ||= @vars.map{|(k,v)| "#{k} = #{evaluable_string(v)}" } * '; '
       end
 
       def bounded_val(var, binding)

--- a/lib/serializable_proc/marshalable.rb
+++ b/lib/serializable_proc/marshalable.rb
@@ -1,3 +1,5 @@
+require "base64"
+
 class SerializableProc
   module Marshalable
 
@@ -37,8 +39,8 @@ class SerializableProc
 
       protected
 
-        def mdump(val)
-          Marshal.dump(val).gsub('|','\|')
+        def evaluable_string(val)
+          "Marshal.load(Base64.strict_decode64(%q|#{Base64.strict_encode64(Marshal.dump(val)).gsub('|','\|')}|))"
         end
 
         def mclone(val)

--- a/spec/proc_like/marshalling_spec.rb
+++ b/spec/proc_like/marshalling_spec.rb
@@ -39,6 +39,12 @@ describe 'Marshalling' do
       Marshal.load(Marshal.dump(s_proc)).call.should.equal('#{')
     end
 
+    should 'handle local variables that marshal with some non-friendly char' do
+      require 'time'
+      v = Time.parse('Mon, 16 Jun 2014 11:23:13')
+      s_proc = SerializableProc.new{ v }
+      Marshal.load(Marshal.dump(s_proc)).call.should.equal(v)
+    end      
 
     should 'handle instance variables' do
       @x, @y, expected = 'awe', 'some', 'awesome'


### PR DESCRIPTION
Another fix for the Binding.eval! - encode/decode base64 to make binding evaluation completely safe since apparently there are some chars ruby doesn't like to see in a string that marshalling produces. Something related to marshalling Time objects in particular. 
