### PR TITLE
isolate/ignore constructor options, to deprecate the old @@_not_isolated...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,20 +29,29 @@ proc's scope, thus, achieving a snapshot effect.
   s_proc.call # >> "lx, ix, cx, gx"
   v_proc.call # >> "ly, iy, cy, gy"
 
-Sometimes, we may want global variables to behave as truely global, meaning we don't want
-to isolate globals at all, this can be done by declaring @@_not_isolated_vars within the
-code block:
+Sometimes, we may want global variables to behave as truly global, meaning we don't want
+to isolate globals at all, this can be done by specifying :ignore option in the constructor call:
 
-  s_proc = SerializableProc.new do
-    @@_not_isolated_vars = :global # globals won't be isolated
+  s_proc = SerializableProc.new(ignore: :global) do
     $stdout << "WakeUp !!"         # $stdout is the $stdout in the execution context
   end
 
 Supported values are :global, :class, :instance, :local & :all, with :all overriding
 all others. The following declares all variables as not isolatable:
 
-  s_proc = SerializableProc.new do
-    @@_not_isolated_vars = :all
+  s_proc = SerializableProc.new(ignore: :all) do
+    ...
+  end
+
+You can also set :isolate option explicitly in the constructor to specify which variable types should be isolated. The supported values as same as for the :ignore option. The following will isolate only locals:
+
+  s_proc = SerializableProc.new(isolate: :local) do
+    ...
+  end
+
+Note that the :ignore option will be processed on top of the :isolate option. The following will isolate only locals:
+
+  s_proc = SerializableProc.new(isolate: :all, ignore: [:global, :class, :instance]) do
     ...
   end
 

--- a/spec/isolation/isolation_spec.rb
+++ b/spec/isolation/isolation_spec.rb
@@ -1,0 +1,88 @@
+require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+
+describe 'Isolating variables (new syntax)' do
+
+  extend SerializableProc::Spec::Helpers
+
+  should 'isolate all vars if isolation not specified' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new {
+        [x, @x, @@x, $x]
+      }, {:lvar_x => x, :ivar_x => @x, :cvar_x => @@x, :gvar_x => $x}
+  end
+
+  should 'isolate no vars if isolate is []' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: []) {
+        [x, @x, @@x, $x]
+      }, {}
+  end
+
+  should 'isolate all vars if isolate: :all' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: :all) {
+        [x, @x, @@x, $x]
+      }, {:lvar_x => x, :ivar_x => @x, :cvar_x => @@x, :gvar_x => $x}
+  end
+
+  should 'isolate all vars if isolate: [:all]' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: [:all]) {
+        [x, @x, @@x, $x]
+      }, {:lvar_x => x, :ivar_x => @x, :cvar_x => @@x, :gvar_x => $x}
+  end
+
+  should 'ignore no vars if ignore: :all' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(ignore: :all) {
+        [x, @x, @@x, $x]
+      }, {}
+  end
+
+  should 'isolate locals if isolate: :all and ignore: all except locals' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: :all, ignore: [:global, :class, :instance]) {
+        [x, @x, @@x, $x]
+      }, {:lvar_x => x}
+  end
+
+  should 'isolate no vars if ignore same as isolate (ignore overrides isolate)' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: :local, ignore: :local) {
+        [x, @x, @@x, $x]
+      }, {}
+  end
+
+  should 'isolate all except for the ones specified in ignore if isolate not specified' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(ignore: :local) {
+        [x, @x, @@x, $x]
+      }, {:ivar_x => @x, :cvar_x => @@x, :gvar_x => $x}
+  end
+
+  should 'use @not_isolated_vars in case @ignore not specified' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: :all) {
+        @@_not_isolated_vars = :local, :global
+        [x, @x, @@x, $x]
+      }, {:ivar_x => @x, :cvar_x => @@x}
+  end
+
+  should 'use @ignore over @not_isolated_vars in case @ignore is specified' do
+    x, @x, @@x, $x = 'lx', 'ix', 'cx', 'gx'
+    should_have_expected_binding \
+      SerializableProc.new(isolate: :all, ignore: :local) {
+        @@_not_isolated_vars = :local, :global
+        [x, @x, @@x, $x]
+      }, {:ivar_x => @x, :cvar_x => @@x, :gvar_x => $x}
+  end
+end


### PR DESCRIPTION
..._vars isolation method

Issue https://github.com/ngty/serializable_proc/issues/2

This implementation keeps backwards-compatibility with the old @@_not_isolated_vars method of specifying isolation. 
